### PR TITLE
Add url field to step embeds

### DIFF
--- a/schema/1.0/omanual_guide.xsd
+++ b/schema/1.0/omanual_guide.xsd
@@ -281,6 +281,7 @@
          <xs:attribute name="title" type="xs:string" />
          <xs:attribute name="height" type="xs:integer" />
          <xs:attribute name="width" type="xs:integer" />
+         <xs:attribute name="url" type="xs:anyURI" />
          <xs:attribute name="html" type="xs:string" />
       </xs:complexType>
    </xs:element>

--- a/site/1.0/guide_documentation.php
+++ b/site/1.0/guide_documentation.php
@@ -698,6 +698,7 @@ images or one rich media object, as well as no more than eight lines of text.
                         <li><strong class="req">type</strong> <em>required</em> The resource type. Valid values are [photo, video, link, rich].  Visit the section on these types in the <a href="http://oembed.com/#section2" target="_blank">oembed spec</a> to learn more.</li>
                         <li><strong class="req">version</strong> <em>required</em> The <a href="http://oembed.com/#section2" target="_blank">oEmbed</a> version number. This must be <code>1.0</code>.</li>
                         <li><strong>html</strong> <em>optional</em> The body of the embed object, could be an iframe embeded content or a block of html depending on the type.</li>
+                        <li><strong>url</strong> <em>optional</em> URL to the source of the embedded media.</li>
                         <li><strong>height</strong> <em>optional</em> The height of the embedded object.</li>
                         <li><strong>width</strong> <em>optional</em> The width of the embedded object.</li>
                         <li><strong>title</strong> <em>optional</em> A text title, describing the resource.</li>


### PR DESCRIPTION
The oEmbed spec requires it, so we should have it as a field field for step embeds.

Fixes #6 
